### PR TITLE
fix(request.js): 修复个别手机机型请求失败的bug

### DIFF
--- a/utils/request.js
+++ b/utils/request.js
@@ -5,7 +5,7 @@
 function request (opts) {
   if (!opts.url) return;
   opts.method = opts.method || 'GET'
-  var { url, data } = handleParam(opts);
+  var { url, data } = handleParam(opts)
 
   return new Promise(function (resolve, reject) {
     wx.request({
@@ -35,7 +35,7 @@ function handleParam (opts) {
   urlArr = urlArr.map(item => {
     if (item.charAt(0) === ':') {
       var field = String(item).substring(1)
-      item = data[field]
+      item = encodeURIComponent(data[field])
       delete data[field]
     }
     return item


### PR DESCRIPTION
部分手机点击按钮后发送请求总是失败，原因是 restful 接口导致。

请求地址为：`https://xxxxxxx/993路?direction=1`，请求 url 为 `https://xxxxxxx/993路`。
有的手机可以将 url 中中文汉字 【路】编码为【%E8%B7%AF】,此时请求就会成功。
但有的手机并不会对 url 中中文汉字进行编码，请求总是会失败。

解决方法为在代码中手动对中文进行编码。


 